### PR TITLE
Fix https://github.com/FormularSumo/Star-Wars-Galaxy-Collection/issues/115

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -481,13 +481,15 @@ function love.update(dt)
 
     --Manage song queue and background video looping
     if not paused then
-        if songs[1] and not songs[currentSong]:isPlaying() then
-            if songs[currentSong+1] then
-                currentSong = currentSong+1
-            else
-                currentSong = 1
+        if songs[1] and not songs[currentSong]:isPlaying() then --Check if a song is currently playing
+            if songs[currentSong]:tell() == 0 then --Check that the current song isn't playing because it's finished rather than because the system is lagging a lot
+                if songs[currentSong+1] then
+                    currentSong = currentSong+1
+                else
+                    currentSong = 1
+                end
             end
-            songs[currentSong]:play()
+            songs[currentSong]:play() --We want this to happen regardless of whether we switch to the next song, as at this point the game is not paused but no song is playing (presumably stopped due to lag)
         end
 
         if background['Video'] and not background['Background']:isPlaying() then


### PR DESCRIPTION
This is done by checking that the current song has reached the end as well as not currently playing. In either case, the "current" song wants playing, as otherwise it gets stopped entirely if stopped due to lag.