### PR TITLE
Change name of SpriteBatch index variables in Projectile/Weapon

### DIFF
--- a/Projectile.lua
+++ b/Projectile.lua
@@ -11,7 +11,7 @@ function Projectile:init(team,xoffset,yoffset,range,imageName,imagePath)
 end
 
 function Projectile:init2(image)
-    self.image = image:add(0,0,0,0,0)
+    self.imageSpriteIndex = image:add(0,0,0,0,0)
     self.width,self.height = image:getTexture():getDimensions()
     
     if self.team == 1 then
@@ -24,7 +24,7 @@ function Projectile:init2(image)
 end
 
 function Projectile:fire(card,card2)
-    if self.image then --Otherwise in theory it could crash if image decoding hasn't finished yet (would have to be extremely slow hardware)
+    if self.imageSpriteIndex then --Otherwise in theory it could crash if image decoding hasn't finished yet (would have to be extremely slow hardware)
         self.show = true
         if self.inverse then
             self.x = card2.x + self.xoffset
@@ -52,7 +52,7 @@ function Projectile:fire(card,card2)
 end
 
 function Projectile:update(dt)
-    if self.show and self.image then
+    if self.show and self.imageSpriteIndex then
         self.x = self.x + (self.xDistance * dt) / 0.9
         self.y = self.y + (self.yDistance * dt) / 0.9
     end
@@ -60,11 +60,11 @@ end
 
 function Projectile:hideProjectile(graphics)
     self.show = false
-    graphics[self.imagePath]:set(self.image,0,0,0,0,0)
+    graphics[self.imagePath]:set(self.imageSpriteIndex,0,0,0,0,0)
 end
 
 function Projectile:render(graphics)
     if self.show and self.xDistance then --Checking if self.xDistance means that if somehow Projectile:fire wasn't run because the image wasn't loaded, a projectile with no destination/movement won't be shown (rather non will)
-        graphics[self.imagePath]:set(self.image,self.x,self.y,self.angle)
+        graphics[self.imagePath]:set(self.imageSpriteIndex,self.x,self.y,self.angle)
     end
 end

--- a/Weapon.lua
+++ b/Weapon.lua
@@ -20,7 +20,7 @@ function Weapon:init(number,team,xoffset,yoffset,card,imageName,imagePath)
 end
 
 function Weapon:init2(image)
-    self.image = image:add(0,0,0,0,0)
+    self.imageSpriteIndex = image:add(0,0,0,0,0)
     self.width,self.height = image:getTexture():getDimensions()
     
     if self.double or self.shield then self.yoriginoffset = self.height/2 end
@@ -72,17 +72,17 @@ function Weapon:init2(image)
 end
 
 function Weapon:hideWeapon(graphics)
-    if self.image then
-        graphics[self.imagePath]:set(self.image,0,0,0,0,0)
+    if self.imageSpriteIndex then
+        graphics[self.imagePath]:set(self.imageSpriteIndex,0,0,0,0,0)
     end
 end
 
 function Weapon:render(graphics,angle)
-    if self.image then
+    if self.imageSpriteIndex then
         if self.static then
-            graphics[self.imagePath]:set(self.image,self.card.x+self.xoffset,self.card.y+self.yoffset,0,self.scalefactorx,1,self.width/2,self.yoriginoffset)
+            graphics[self.imagePath]:set(self.imageSpriteIndex,self.card.x+self.xoffset,self.card.y+self.yoffset,0,self.scalefactorx,1,self.width/2,self.yoriginoffset)
         else
-            graphics[self.imagePath]:set(self.image,self.card.x+self.xoffset,self.card.y+self.yoffset,angle,self.scalefactorx,1,self.width/2,self.yoriginoffset)
+            graphics[self.imagePath]:set(self.imageSpriteIndex,self.card.x+self.xoffset,self.card.y+self.yoffset,angle,self.scalefactorx,1,self.width/2,self.yoriginoffset)
         end
     end
 end


### PR DESCRIPTION
They're not images, only indexes in the SpriteBatch table, so makes sense to name them as so